### PR TITLE
Fix manual implementation of `Option::map` lint

### DIFF
--- a/libaugrim/src/error/internal.rs
+++ b/libaugrim/src/error/internal.rs
@@ -142,10 +142,7 @@ impl InternalError {
 
 impl error::Error for InternalError {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        match &self.source {
-            Some(s) => Some(s.source.as_ref()),
-            None => None,
-        }
+        self.source.as_ref().map(|s| s.source.as_ref())
     }
 }
 


### PR DESCRIPTION
This change fixes a lint introduced in the 1.52.0 release of Rust
flagging items like

    match Some(0) {
        Some(x) => Some(x + 1),
        None => None,
    };

Use instead:

    Some(0).map(|x| x + 1);

In some cases this requires an `as &(dyn Error + 'static)` as the option
includes a `Send` constraint as well.

In some cases this can be replaced with a `as_deref` call.

See for
    https://rust-lang.github.io/rust-clippy/master/index.html#manual_map
for details
