### PR TITLE
Add algorithm trait

### DIFF
--- a/libaugrim/src/algorithm/mod.rs
+++ b/libaugrim/src/algorithm/mod.rs
@@ -11,3 +11,25 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+use crate::error::InternalError;
+use crate::process::Process;
+
+pub trait Action {}
+pub trait Context {}
+pub trait Value: Clone {}
+
+pub trait Algorithm<P>
+where
+    P: Process,
+{
+    type Event;
+    type Action;
+    type Context;
+
+    fn event(
+        &self,
+        event: Self::Event,
+        context: Self::Context,
+    ) -> Result<Vec<Self::Action>, InternalError>;
+}


### PR DESCRIPTION
The error type will likely change in the future to AlgorithmError with two variants (InternalError/InvalidSateError), but for now keeping it InternalError to match the work-in-progress implementations.