### PR TITLE
Return AlgorithmError from Algorithm.event()

### DIFF
--- a/libaugrim/src/algorithm/mod.rs
+++ b/libaugrim/src/algorithm/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::error::InternalError;
+use crate::error::AlgorithmError;
 use crate::process::Process;
 
 #[cfg(feature = "algorithm-two-phase-commit")]
@@ -34,5 +34,5 @@ where
         &self,
         event: Self::Event,
         context: Self::Context,
-    ) -> Result<Vec<Self::Action>, InternalError>;
+    ) -> Result<Vec<Self::Action>, AlgorithmError>;
 }

--- a/libaugrim/src/algorithm/two_phase_commit/coordinator_algorithm.rs
+++ b/libaugrim/src/algorithm/two_phase_commit/coordinator_algorithm.rs
@@ -16,7 +16,7 @@ use std::marker::PhantomData;
 use std::time::Duration;
 
 use crate::algorithm::{Algorithm, Value};
-use crate::error::InternalError;
+use crate::error::AlgorithmError;
 use crate::process::Process;
 use crate::time::TimeSource;
 
@@ -135,7 +135,7 @@ where
         &self,
         event: Self::Event,
         mut context: Self::Context,
-    ) -> Result<Vec<Self::Action>, InternalError> {
+    ) -> Result<Vec<Self::Action>, AlgorithmError> {
         match event {
             // In response to a RequestForStart notification, a Start event provides the next value
             // that should be considered.

--- a/libaugrim/src/error/algorithm.rs
+++ b/libaugrim/src/error/algorithm.rs
@@ -1,0 +1,49 @@
+// Copyright 2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Contains AlgorithmError
+
+use std::error::Error;
+use std::fmt::{Display, Formatter, Result as FormatResult};
+
+use super::InternalError;
+use super::InvalidStateError;
+
+/// An error which can occur while an `Algorithm` is processing `Event`s.
+#[derive(Debug)]
+pub enum AlgorithmError {
+    /// The provided `Event` can not be run with the provided context.
+    InvalidState(InvalidStateError),
+
+    /// The algorithm could not process the event due to an unexpected internal error.
+    Internal(InternalError),
+}
+
+impl Error for AlgorithmError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            AlgorithmError::InvalidState(e) => Some(e),
+            AlgorithmError::Internal(e) => Some(e),
+        }
+    }
+}
+
+impl Display for AlgorithmError {
+    fn fmt(&self, f: &mut Formatter) -> FormatResult {
+        match self {
+            AlgorithmError::InvalidState(e) => write!(f, "{}", e),
+            AlgorithmError::Internal(e) => write!(f, "{}", e),
+        }
+    }
+}

--- a/libaugrim/src/error/invalid_state.rs
+++ b/libaugrim/src/error/invalid_state.rs
@@ -1,0 +1,71 @@
+// Copyright 2018-2022 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Module containing InvalidStateError implementation.
+
+use std::error;
+use std::fmt;
+
+/// An error returned when an operation cannot be completed because the state of the underlying
+/// struct is inconsistent.
+///
+/// This can be caused by a caller when a sequence of functions is called in a way that results in
+/// a state which is inconsistent.
+///
+/// This usually indicates a programming error on behalf of the caller.
+#[derive(Debug)]
+pub struct InvalidStateError {
+    message: String,
+}
+
+impl InvalidStateError {
+    /// Constructs a new `InvalidStateError` with a specified message string.
+    ///
+    /// The implementation of `std::fmt::Display` for this error will be the message string
+    /// provided.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use augrim::error::InvalidStateError;
+    ///
+    /// let invalid_state_error = InvalidStateError::with_message("oops".to_string());
+    /// assert_eq!(format!("{}", invalid_state_error), "oops");
+    /// ```
+    pub fn with_message(message: String) -> Self {
+        Self { message }
+    }
+}
+
+impl error::Error for InvalidStateError {}
+
+impl fmt::Display for InvalidStateError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", &self.message)
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    /// Tests that error constructed with `InvalidStateError::with_message` return message as the
+    /// display string.
+    #[test]
+    fn test_display_with_message() {
+        let msg = "test message";
+        let err = InvalidStateError::with_message(msg.to_string());
+        assert_eq!(format!("{}", err), msg);
+    }
+}

--- a/libaugrim/src/error/mod.rs
+++ b/libaugrim/src/error/mod.rs
@@ -75,5 +75,7 @@
 //! ```
 
 mod internal;
+mod invalid_state;
 
 pub use internal::InternalError;
+pub use invalid_state::InvalidStateError;

--- a/libaugrim/src/error/mod.rs
+++ b/libaugrim/src/error/mod.rs
@@ -74,8 +74,12 @@
 //! }
 //! ```
 
+#[cfg(feature = "algorithm")]
+mod algorithm;
 mod internal;
 mod invalid_state;
 
+#[cfg(feature = "algorithm")]
+pub use algorithm::AlgorithmError;
 pub use internal::InternalError;
 pub use invalid_state::InvalidStateError;


### PR DESCRIPTION
AlgorithmError allows InvalidStateError to be returned in addition to InternalError.