### PR TITLE
Relax Copy constraint on Process

### DIFF
--- a/libaugrim/src/algorithm/two_phase_commit/coordinator_algorithm.rs
+++ b/libaugrim/src/algorithm/two_phase_commit/coordinator_algorithm.rs
@@ -83,7 +83,7 @@ where
             .filter(|p| p.vote.unwrap_or(false))
         {
             actions.push(CoordinatorAction::SendMessage(
-                participant.process,
+                participant.process.clone(),
                 TwoPhaseCommitMessage::Abort(*context.epoch()),
             ))
         }
@@ -150,7 +150,7 @@ where
                 // Send a VoteRequest message to all participants
                 for participant in context.participants() {
                     actions.push(CoordinatorAction::SendMessage(
-                        participant.process,
+                        participant.process.clone(),
                         TwoPhaseCommitMessage::VoteRequest(*context.epoch(), value.clone()),
                     ))
                 }
@@ -189,7 +189,7 @@ where
                     // Send `Commit` to all participants.
                     for participant in context.participants() {
                         actions.push(CoordinatorAction::SendMessage(
-                            participant.process,
+                            participant.process.clone(),
                             TwoPhaseCommitMessage::Commit(*context.epoch()),
                         ))
                     }

--- a/libaugrim/src/process.rs
+++ b/libaugrim/src/process.rs
@@ -21,4 +21,4 @@
 ///
 /// [^note]: For a full explanation of processes and the relation to other components, see Cachin,
 /// Guerraoui, and Rodrigues, Reliable and Secure Distributed Programming, 2nd ed., 2.1.1.
-pub trait Process: Copy + Eq + PartialEq {}
+pub trait Process: Clone + Eq + PartialEq {}


### PR DESCRIPTION
This change relaxes the copy constraint to Clone, in order to support more possible types as a process value (e.g. strings, etc), while still supporting Copy types (e.g. integers, etc) as they all implement `Clone` automatically.
