### PR TITLE
Add From impls for AlgorithmError variants

### DIFF
--- a/libaugrim/src/error/algorithm.rs
+++ b/libaugrim/src/error/algorithm.rs
@@ -47,3 +47,15 @@ impl Display for AlgorithmError {
         }
     }
 }
+
+impl From<InvalidStateError> for AlgorithmError {
+    fn from(err: InvalidStateError) -> Self {
+        AlgorithmError::InvalidState(err)
+    }
+}
+
+impl From<InternalError> for AlgorithmError {
+    fn from(err: InternalError) -> Self {
+        AlgorithmError::Internal(err)
+    }
+}


### PR DESCRIPTION
This change adds the `From` impls for the wrapping error variants.
