### PR TITLE
Remove Alarm structs in favor of Option<T>

### DIFF
--- a/libaugrim/src/algorithm/two_phase_commit/coordinator_action.rs
+++ b/libaugrim/src/algorithm/two_phase_commit/coordinator_action.rs
@@ -19,21 +19,16 @@ use crate::time::Time;
 use super::CoordinatorContext;
 use super::TwoPhaseCommitMessage;
 
-pub enum CoordinatorActionAlarm<T>
-where
-    T: Time,
-{
-    Set(T),
-    Unset,
-}
-
 pub enum CoordinatorAction<P, V, T>
 where
     P: Process,
     V: Value,
     T: Time,
 {
-    Update(CoordinatorContext<P, T>, CoordinatorActionAlarm<T>),
+    Update {
+        context: CoordinatorContext<P, T>,
+        alarm: Option<T>,
+    },
     SendMessage(P, TwoPhaseCommitMessage<V>),
     Notify(CoordinatorActionNotification),
 }

--- a/libaugrim/src/algorithm/two_phase_commit/mod.rs
+++ b/libaugrim/src/algorithm/two_phase_commit/mod.rs
@@ -24,17 +24,13 @@ mod participant_context;
 mod participant_event;
 mod participant_message;
 
-pub use coordinator_action::{
-    CoordinatorAction, CoordinatorActionAlarm, CoordinatorActionNotification,
-};
+pub use coordinator_action::{CoordinatorAction, CoordinatorActionNotification};
 pub use coordinator_algorithm::CoordinatorAlgorithm;
 pub use coordinator_context::{CoordinatorContext, CoordinatorState};
 pub use coordinator_event::CoordinatorEvent;
 pub use coordinator_message::CoordinatorMessage;
 pub use message::TwoPhaseCommitMessage;
-pub use participant_action::{
-    ParticipantAction, ParticipantActionAlarm, ParticipantActionNotification,
-};
+pub use participant_action::{ParticipantAction, ParticipantActionNotification};
 pub use participant_algorithm::ParticipantAlgorithm;
 pub use participant_context::{ParticipantContext, ParticipantState};
 pub use participant_event::ParticipantEvent;

--- a/libaugrim/src/algorithm/two_phase_commit/participant_action.rs
+++ b/libaugrim/src/algorithm/two_phase_commit/participant_action.rs
@@ -19,14 +19,6 @@ use crate::time::Time;
 use super::ParticipantContext;
 use super::TwoPhaseCommitMessage;
 
-pub enum ParticipantActionAlarm<T>
-where
-    T: Time,
-{
-    Set(T),
-    Unset,
-}
-
 pub enum ParticipantAction<P, V, T>
 where
     P: Process,
@@ -35,7 +27,10 @@ where
 {
     Notify(ParticipantActionNotification<V>),
     SendMessage(P, TwoPhaseCommitMessage<V>),
-    Update(ParticipantContext<P, T>, ParticipantActionAlarm<T>),
+    Update {
+        context: ParticipantContext<P, T>,
+        alarm: Option<T>,
+    },
 }
 
 impl<P, V, T> Action for ParticipantAction<P, V, T>

--- a/libaugrim/src/algorithm/two_phase_commit/participant_algorithm.rs
+++ b/libaugrim/src/algorithm/two_phase_commit/participant_algorithm.rs
@@ -21,7 +21,6 @@ use crate::process::Process;
 use crate::time::TimeSource;
 
 use super::ParticipantAction;
-use super::ParticipantActionAlarm;
 use super::ParticipantActionNotification;
 use super::ParticipantContext;
 use super::ParticipantEvent;
@@ -129,10 +128,10 @@ where
                             vote: *vote,
                             decision_timeout_start: new_decision_timeout_start,
                         });
-                        actions.push(ParticipantAction::Update(
-                            new_context,
-                            ParticipantActionAlarm::Set(new_decision_timeout_end),
-                        ));
+                        actions.push(ParticipantAction::Update {
+                            context: new_context,
+                            alarm: Some(new_decision_timeout_end),
+                        });
                     }
 
                     Ok(actions)
@@ -188,10 +187,10 @@ where
 
                 // Update the context with the new state of WaitingForVote
                 context.set_state(ParticipantState::WaitingForVote);
-                actions.push(ParticipantAction::Update(
+                actions.push(ParticipantAction::Update {
                     context,
-                    ParticipantActionAlarm::Unset,
-                ));
+                    alarm: None,
+                });
 
                 // Send a RequestForVote notification
                 actions.push(ParticipantAction::Notify(
@@ -228,10 +227,10 @@ where
 
                 // The vote was no, so record our decision to Abort.
                 context.set_state(ParticipantState::Commit);
-                actions.push(ParticipantAction::Update(
-                    context.clone(),
-                    ParticipantActionAlarm::Unset,
-                ));
+                actions.push(ParticipantAction::Update {
+                    context: context.clone(),
+                    alarm: None,
+                });
 
                 Ok(actions)
             }
@@ -263,10 +262,10 @@ where
 
                 // The vote was no, so record our decision to Abort.
                 context.set_state(ParticipantState::Abort);
-                actions.push(ParticipantAction::Update(
-                    context.clone(),
-                    ParticipantActionAlarm::Unset,
-                ));
+                actions.push(ParticipantAction::Update {
+                    context: context.clone(),
+                    alarm: None,
+                });
 
                 Ok(actions)
             }
@@ -348,17 +347,17 @@ where
                         vote,
                         decision_timeout_start,
                     });
-                    actions.push(ParticipantAction::Update(
-                        context.clone(),
-                        ParticipantActionAlarm::Set(decision_timeout_end),
-                    ));
+                    actions.push(ParticipantAction::Update {
+                        context: context.clone(),
+                        alarm: Some(decision_timeout_end),
+                    });
                 } else {
                     // The vote was no, so record our decision to Abort.
                     context.set_state(ParticipantState::Abort);
-                    actions.push(ParticipantAction::Update(
-                        context.clone(),
-                        ParticipantActionAlarm::Unset,
-                    ));
+                    actions.push(ParticipantAction::Update {
+                        context: context.clone(),
+                        alarm: None,
+                    });
                 }
 
                 // Send the vote to the coordinator.


### PR DESCRIPTION
Alarm was too close to Option, with Set(T), Unset variants which are
easily covered by Option Some(T), None.

Updates CoordinatorAction::Update and ParticipantAction::Update enum
variants to explicitly call the parameter "alarm" since it would
otherwise be less clear than with the custom CoordinatorActionAlarm and
ParticipantActionAlarm structs.