### PR TITLE
Derive Debug and PartialEq on several structs

### DIFF
--- a/libaugrim/src/algorithm/two_phase_commit/coordinator_context.rs
+++ b/libaugrim/src/algorithm/two_phase_commit/coordinator_context.rs
@@ -15,7 +15,7 @@
 use crate::process::Process;
 use crate::time::Time;
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Participant<P> {
     pub process: P,
     pub vote: Option<bool>,
@@ -42,7 +42,7 @@ where
     WaitingForVote,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct CoordinatorContext<P, T>
 where
     P: Process,

--- a/libaugrim/src/algorithm/two_phase_commit/participant_context.rs
+++ b/libaugrim/src/algorithm/two_phase_commit/participant_context.rs
@@ -30,7 +30,7 @@ where
     WaitingForVote,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ParticipantContext<P, T>
 where
     P: Process,

--- a/libaugrim/src/algorithm/two_phase_commit/unified_action.rs
+++ b/libaugrim/src/algorithm/two_phase_commit/unified_action.rs
@@ -19,6 +19,7 @@ use crate::time::Time;
 use super::TwoPhaseCommitContext;
 use super::TwoPhaseCommitMessage;
 
+#[derive(Debug, PartialEq)]
 pub enum TwoPhaseCommitAction<P, V, T>
 where
     P: Process,
@@ -41,6 +42,7 @@ where
 {
 }
 
+#[derive(Debug, PartialEq)]
 pub enum TwoPhaseCommitActionNotification<V>
 where
     V: Value,

--- a/libaugrim/src/algorithm/two_phase_commit/unified_context.rs
+++ b/libaugrim/src/algorithm/two_phase_commit/unified_context.rs
@@ -22,7 +22,7 @@ use super::TwoPhaseCommitState;
 use super::{CoordinatorContext, CoordinatorState, Participant};
 use super::{ParticipantContext, ParticipantState};
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct TwoPhaseCommitContext<P, T, R = TwoPhaseCommitRoleContext<P, T>>
 where
     P: Process,

--- a/libaugrim/src/algorithm/two_phase_commit/unified_message.rs
+++ b/libaugrim/src/algorithm/two_phase_commit/unified_message.rs
@@ -17,7 +17,7 @@ use crate::message::Message;
 
 use super::Epoch;
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum TwoPhaseCommitMessage<V>
 where
     V: Value,

--- a/libaugrim/src/algorithm/two_phase_commit/unified_role.rs
+++ b/libaugrim/src/algorithm/two_phase_commit/unified_role.rs
@@ -20,7 +20,7 @@ use super::ParticipantContext;
 use super::TwoPhaseCommitState;
 use super::{CoordinatorContext, Participant};
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 enum InnerContext<P, T>
 where
     P: Process,
@@ -30,7 +30,7 @@ where
     Participant(ParticipantContext<P, T>),
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct TwoPhaseCommitRoleContext<P, T>
 where
     P: Process,


### PR DESCRIPTION
When testing and using assertions (such as assert_eq), it is useful to
have Debug and PartialEq on most of the structs. This adds them in
places which were useful in initial test writing.

