### PR TITLE
Add notifications to 2pc after a commit or abort

### DIFF
--- a/libaugrim/src/two_phase_commit/coordinator_algorithm.rs
+++ b/libaugrim/src/two_phase_commit/coordinator_algorithm.rs
@@ -204,6 +204,11 @@ where
                         ))
                     }
 
+                    // Notify that we've committed.
+                    actions.push(CoordinatorAction::Notify(
+                        CoordinatorActionNotification::Commit(),
+                    ));
+
                     // Always advance the epoch immediately after a commit decision.
                     self.push_advance_epoch_actions(context, &mut actions);
                 } else {

--- a/libaugrim/src/two_phase_commit/coordinator_algorithm.rs
+++ b/libaugrim/src/two_phase_commit/coordinator_algorithm.rs
@@ -94,14 +94,14 @@ where
         ));
 
         // When an abort decision is made, always advance the epoch as well.
-        self.push_advance_epoch_actions(context, actions);
+        self.push_advance_epoch_actions(&mut context, actions);
     }
 
     // Create actions for advancing to the next epoch. This set of actions is generated whenever
     // a decision has been reached, either abort or commit.
     fn push_advance_epoch_actions(
         &self,
-        mut context: TwoPhaseCommitContext<P, TS::Time, CoordinatorContext<P, TS::Time>>,
+        context: &mut TwoPhaseCommitContext<P, TS::Time, CoordinatorContext<P, TS::Time>>,
         actions: &mut Vec<CoordinatorAction<P, V, TS::Time>>,
     ) {
         // Update the epoch and set the state to WaitingForStart. Also update the last commit epoch
@@ -110,7 +110,7 @@ where
         context.set_epoch(context.epoch() + 1);
         context.set_state(CoordinatorState::WaitingForStart);
         actions.push(CoordinatorAction::Update {
-            context,
+            context: context.clone(),
             alarm: None,
         });
 
@@ -210,7 +210,7 @@ where
                     ));
 
                     // Always advance the epoch immediately after a commit decision.
-                    self.push_advance_epoch_actions(context, &mut actions);
+                    self.push_advance_epoch_actions(&mut context, &mut actions);
                 } else {
                     self.push_abort_actions(context, &mut actions);
                 }
@@ -257,7 +257,7 @@ where
                 // advancing to the next epoch.
                 CoordinatorState::Commit => {
                     let mut actions = Vec::new();
-                    self.push_advance_epoch_actions(context, &mut actions);
+                    self.push_advance_epoch_actions(&mut context, &mut actions);
                     Ok(actions)
                 }
 
@@ -265,7 +265,7 @@ where
                 // advancing to the next epoch.
                 CoordinatorState::Abort => {
                     let mut actions = Vec::new();
-                    self.push_advance_epoch_actions(context, &mut actions);
+                    self.push_advance_epoch_actions(&mut context, &mut actions);
                     Ok(actions)
                 }
             },

--- a/libaugrim/src/two_phase_commit/coordinator_algorithm.rs
+++ b/libaugrim/src/two_phase_commit/coordinator_algorithm.rs
@@ -109,6 +109,10 @@ where
         context.set_last_commit_epoch(Some(*context.epoch()));
         context.set_epoch(context.epoch() + 1);
         context.set_state(CoordinatorState::WaitingForStart);
+        context
+            .participants_mut()
+            .iter_mut()
+            .for_each(|participant| participant.vote = None);
         actions.push(CoordinatorAction::Update {
             context: context.clone(),
             alarm: None,

--- a/libaugrim/src/two_phase_commit/participant_algorithm.rs
+++ b/libaugrim/src/two_phase_commit/participant_algorithm.rs
@@ -233,6 +233,11 @@ where
                     alarm: None,
                 });
 
+                // Notify that we've committed.
+                actions.push(ParticipantAction::Notify(
+                    ParticipantActionNotification::Commit(),
+                ));
+
                 Ok(actions)
             }
             ParticipantEvent::Deliver(_process, ParticipantMessage::Abort(epoch)) => {
@@ -267,6 +272,11 @@ where
                     context: context.clone(),
                     alarm: None,
                 });
+
+                // Notify that we've aborted.
+                actions.push(ParticipantAction::Notify(
+                    ParticipantActionNotification::Abort(),
+                ));
 
                 Ok(actions)
             }
@@ -359,6 +369,11 @@ where
                         context: context.clone(),
                         alarm: None,
                     });
+
+                    // Notify that we've aborted.
+                    actions.push(ParticipantAction::Notify(
+                        ParticipantActionNotification::Abort(),
+                    ));
                 }
 
                 // Send the vote to the coordinator.


### PR DESCRIPTION
Send a notification when commit or abort occurs so observers can take
the appropriate action.
