### PR TITLE
Fix check for not in Voting state

### DIFF
--- a/libaugrim/src/two_phase_commit/coordinator_algorithm.rs
+++ b/libaugrim/src/two_phase_commit/coordinator_algorithm.rs
@@ -303,7 +303,7 @@ where
                 // in practice because we will have advanced the epoch and the epoch is checked
                 // above; however, this could occur if not all Update actions were run
                 // successfully.
-                if matches!(
+                if !matches!(
                     context_state,
                     CoordinatorState::Voting {
                         vote_timeout_start: _,


### PR DESCRIPTION
This should be checking if NOT in the Voting state. As this
should rarely happen, this incorrect check was being hit everytime.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>