### PR TITLE
Fix last committed bug

### DIFF
--- a/libaugrim/src/two_phase_commit/coordinator_algorithm.rs
+++ b/libaugrim/src/two_phase_commit/coordinator_algorithm.rs
@@ -418,9 +418,13 @@ where
                 // know what the future holds. Similarly, we do not yet have a decision for the
                 // current epoch or we would have advanced to the next epoch already.
                 Ok(vec![CoordinatorAction::Notify(
-                    CoordinatorActionNotification::MessageDropped(
-                        "decision for requested epoch is unknown".into(),
-                    ),
+                    CoordinatorActionNotification::MessageDropped(format!(
+                        "decision for requested epoch {} is unknown (current epoch: {}, \
+                        last commit epoch: {:?})",
+                        epoch,
+                        context.epoch(),
+                        context.last_commit_epoch()
+                    )),
                 )])
             }
         }

--- a/libaugrim/src/two_phase_commit/coordinator_algorithm.rs
+++ b/libaugrim/src/two_phase_commit/coordinator_algorithm.rs
@@ -106,7 +106,9 @@ where
     ) {
         // Update the epoch and set the state to WaitingForStart. Also update the last commit epoch
         // used to answer DecisionRequest messages.
-        context.set_last_commit_epoch(Some(*context.epoch()));
+        if *context.state() == CoordinatorState::Commit {
+            context.set_last_commit_epoch(Some(*context.epoch()));
+        }
         context.set_epoch(context.epoch() + 1);
         context.set_state(CoordinatorState::WaitingForStart);
         context


### PR DESCRIPTION
Only set last_commit_epoch if state is Commit

last_commit_epoch was getting set to the previous epoch regardless of
the state; this was a bug, because the definition of last_commit_epoch
is the epoch of the last Commit.

This fixes a bug where a participant can't recover because the
coordinator has essentially forgotten the relevant epoch. After this
patch, that error is recoverable by correcting the value of
last_commit_epoch in the context.