### PR TITLE
Add decision ack after commit/abort

### DIFF
--- a/libaugrim/src/two_phase_commit/coordinator_context.rs
+++ b/libaugrim/src/two_phase_commit/coordinator_context.rs
@@ -19,6 +19,7 @@ use crate::time::Time;
 pub struct Participant<P> {
     pub process: P,
     pub vote: Option<bool>,
+    pub decision_ack: bool,
 }
 
 impl<P> Participant<P> {
@@ -26,6 +27,7 @@ impl<P> Participant<P> {
         Participant {
             process,
             vote: None,
+            decision_ack: false,
         }
     }
 }
@@ -38,6 +40,7 @@ where
     Abort,
     Commit,
     Voting { vote_timeout_start: T },
+    WaitingForDecisionAck { ack_timeout_start: T },
     WaitingForStart,
     WaitingForVote,
 }

--- a/libaugrim/src/two_phase_commit/coordinator_message.rs
+++ b/libaugrim/src/two_phase_commit/coordinator_message.rs
@@ -30,6 +30,7 @@ use super::TwoPhaseCommitMessage;
 pub enum CoordinatorMessage {
     VoteResponse(Epoch, bool),
     DecisionRequest(Epoch),
+    DecisionAck(Epoch),
 }
 
 impl<V> From<CoordinatorMessage> for TwoPhaseCommitMessage<V>
@@ -44,6 +45,7 @@ where
             CoordinatorMessage::DecisionRequest(epoch) => {
                 TwoPhaseCommitMessage::DecisionRequest(epoch)
             }
+            CoordinatorMessage::DecisionAck(epoch) => TwoPhaseCommitMessage::DecisionAck(epoch),
         }
     }
 }
@@ -62,6 +64,7 @@ where
             TwoPhaseCommitMessage::DecisionRequest(epoch) => {
                 Ok(CoordinatorMessage::DecisionRequest(epoch))
             }
+            TwoPhaseCommitMessage::DecisionAck(epoch) => Ok(CoordinatorMessage::DecisionAck(epoch)),
             TwoPhaseCommitMessage::VoteRequest(_, _) => Err(InvalidStateError::with_message(
                 "VoteRequest message cannot be handled by a coordinator".into(),
             )),

--- a/libaugrim/src/two_phase_commit/participant_algorithm.rs
+++ b/libaugrim/src/two_phase_commit/participant_algorithm.rs
@@ -224,7 +224,7 @@ where
 
                 Ok(actions)
             }
-            ParticipantEvent::Deliver(_process, ParticipantMessage::Commit(epoch)) => {
+            ParticipantEvent::Deliver(process, ParticipantMessage::Commit(epoch)) => {
                 // A Commit must be for the current epoch to be processed, drop it otherwise.
                 if *context.epoch() != epoch {
                     return Ok(vec![ParticipantAction::Notify(
@@ -260,6 +260,12 @@ where
                 // Notify that we've committed.
                 actions.push(ParticipantAction::Notify(
                     ParticipantActionNotification::Commit(),
+                ));
+
+                // Send an acknowledgement back to the coordinator.
+                actions.push(ParticipantAction::SendMessage(
+                    process,
+                    TwoPhaseCommitMessage::DecisionAck(epoch),
                 ));
 
                 // Switch to WaitingForVoteRequest to prepare for the next epoch

--- a/libaugrim/src/two_phase_commit/participant_message.rs
+++ b/libaugrim/src/two_phase_commit/participant_message.rs
@@ -74,6 +74,9 @@ where
             TwoPhaseCommitMessage::VoteResponse(_, _) => Err(InvalidStateError::with_message(
                 "VoteResponse message cannot be handled by a participant".into(),
             )),
+            TwoPhaseCommitMessage::DecisionAck(_) => Err(InvalidStateError::with_message(
+                "DecisionAck message cannot be handled by a participant".into(),
+            )),
         }
     }
 }

--- a/libaugrim/src/two_phase_commit/unified_message.rs
+++ b/libaugrim/src/two_phase_commit/unified_message.rs
@@ -27,6 +27,7 @@ where
     Commit(Epoch),
     Abort(Epoch),
     DecisionRequest(Epoch),
+    DecisionAck(Epoch),
 }
 
 impl<V> Message for TwoPhaseCommitMessage<V> where V: Value {}

--- a/libaugrim/src/two_phase_commit/unified_state.rs
+++ b/libaugrim/src/two_phase_commit/unified_state.rs
@@ -55,10 +55,12 @@ where
             TwoPhaseCommitState::WaitingForDecisionAck { ack_timeout_start } => {
                 Ok(CoordinatorState::WaitingForDecisionAck { ack_timeout_start })
             }
-            _ => Err(InvalidStateError::with_message(format!(
-                "invalid state for coordinator: {:?}",
-                state
-            ))),
+            TwoPhaseCommitState::WaitingForVoteRequest | TwoPhaseCommitState::Voted { .. } => {
+                Err(InvalidStateError::with_message(format!(
+                    "invalid state for coordinator: {:?}",
+                    state
+                )))
+            }
         }
     }
 }
@@ -84,7 +86,9 @@ where
                 Ok(ParticipantState::WaitingForVoteRequest)
             }
             TwoPhaseCommitState::WaitingForVote => Ok(ParticipantState::WaitingForVote),
-            _ => Err(InvalidStateError::with_message(format!(
+            TwoPhaseCommitState::WaitingForStart
+            | TwoPhaseCommitState::WaitingForDecisionAck { .. }
+            | TwoPhaseCommitState::Voting { .. } => Err(InvalidStateError::with_message(format!(
                 "invalid state for participant: {:?}",
                 state
             ))),

--- a/libaugrim/src/two_phase_commit/unified_state.rs
+++ b/libaugrim/src/two_phase_commit/unified_state.rs
@@ -32,6 +32,9 @@ pub enum TwoPhaseCommitState<T> {
     WaitingForStart,
     WaitingForVoteRequest,
     WaitingForVote,
+    WaitingForDecisionAck {
+        ack_timeout_start: T,
+    },
 }
 
 impl<T> TryFrom<TwoPhaseCommitState<T>> for CoordinatorState<T>
@@ -49,6 +52,9 @@ where
             }
             TwoPhaseCommitState::WaitingForStart => Ok(CoordinatorState::WaitingForStart),
             TwoPhaseCommitState::WaitingForVote => Ok(CoordinatorState::WaitingForVote),
+            TwoPhaseCommitState::WaitingForDecisionAck { ack_timeout_start } => {
+                Ok(CoordinatorState::WaitingForDecisionAck { ack_timeout_start })
+            }
             _ => Err(InvalidStateError::with_message(format!(
                 "invalid state for coordinator: {:?}",
                 state
@@ -99,6 +105,9 @@ where
             }
             CoordinatorState::WaitingForStart => TwoPhaseCommitState::WaitingForStart,
             CoordinatorState::WaitingForVote => TwoPhaseCommitState::WaitingForVote,
+            CoordinatorState::WaitingForDecisionAck { ack_timeout_start } => {
+                TwoPhaseCommitState::WaitingForDecisionAck { ack_timeout_start }
+            }
         }
     }
 }


### PR DESCRIPTION
Previously, the coordinator immediately went to the next epoch after
a decision was reached. This created a potential race condition in the
order of messages received and processed by a participant; if the next
epoch's RequestForVote message was received prior to the Commit/Abort
decision of the current epoch, then the RequestForVote message would be
dropped (because it wasn't for the current epoch). The result of the
dropped message was an eventual timeout and abort of that epoch.

This commit adds a new message sent from the participants to the
coordinator after a decision has been applied: DecisionAck. The
coordinator waits for all DecisionAck messages from all participants,
similar to collecting votes. Once all DecisionAcks are received, then
the coordinator starts the next epoch. If the coordinator times out, it
also starts the next epoch, since it is possible a decision ack will
never be sent by the processes that failed to respond.