### PR TITLE
Unset alarm when handling alarm for WaitingForStart/Vote

### DIFF
--- a/libaugrim/src/two_phase_commit/coordinator_algorithm.rs
+++ b/libaugrim/src/two_phase_commit/coordinator_algorithm.rs
@@ -275,15 +275,30 @@ where
 
                 // If we receive an alarm when in the RequestforStart state, then we re-generate
                 // a RequestForStart notification.
-                CoordinatorState::WaitingForStart => Ok(vec![CoordinatorAction::Notify(
-                    CoordinatorActionNotification::RequestForStart(),
-                )]),
+                //
+                // An alarm in this state is expected to occur during initialization; in that
+                // situation, this alarm is the first event to be processed. If this alarm occurs
+                // in other circumstances, it indicates a bug (possibly in how the caller is using
+                // the algorithm), but we process it anyway in hopes of recovery.
+                CoordinatorState::WaitingForStart => Ok(vec![
+                    CoordinatorAction::Notify(CoordinatorActionNotification::RequestForStart()),
+                    CoordinatorAction::Update {
+                        context,
+                        alarm: None,
+                    },
+                ]),
 
                 // If we receive an alarm an the RequestforStart state, then we re-generate
-                // a RequestForVote notification.
-                CoordinatorState::WaitingForVote => Ok(vec![CoordinatorAction::Notify(
-                    CoordinatorActionNotification::RequestForVote(),
-                )]),
+                // a RequestForVote notification. Since this is unexpected, it indicates a bug
+                // (possibly in how the caller is using the algorithm), but we process it anyway in
+                // hopes of recovery.
+                CoordinatorState::WaitingForVote => Ok(vec![
+                    CoordinatorAction::Notify(CoordinatorActionNotification::RequestForVote()),
+                    CoordinatorAction::Update {
+                        context,
+                        alarm: None,
+                    },
+                ]),
 
                 // A decision ack timeout has occurred, which means we have not received all
                 // decision acks within the allowed timeout period.


### PR DESCRIPTION
Previously, we handled the alarm and did not unset it. With this change,
we unset the alarm.

The algorithm doesn't set an alarm for these states. In the case of
WaitingForVote, no alarm is expected. Thus, it seems correct to unset
the alarm to match the algorithm's expectations.

The same is true for WaitingForStart, with the exception that we do
expect an Alarm to be the first event processed, in order to give the
alogorithm the chance to generate the correct initial notification(s),
in this case RequestForStart.