### PR TITLE
Fix clippy::derive-partial-eq-without-eq lint

### DIFF
--- a/libaugrim/src/two_phase_commit/coordinator_context.rs
+++ b/libaugrim/src/two_phase_commit/coordinator_context.rs
@@ -15,7 +15,7 @@
 use crate::process::Process;
 use crate::time::Time;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Participant<P> {
     pub process: P,
     pub vote: Option<bool>,
@@ -32,7 +32,7 @@ impl<P> Participant<P> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum CoordinatorState<T>
 where
     T: Time,
@@ -45,7 +45,7 @@ where
     WaitingForVote,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CoordinatorContext<P, T>
 where
     P: Process,

--- a/libaugrim/src/two_phase_commit/participant_context.rs
+++ b/libaugrim/src/two_phase_commit/participant_context.rs
@@ -15,7 +15,7 @@
 use crate::process::Process;
 use crate::time::Time;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ParticipantState<T>
 where
     T: Time,
@@ -30,7 +30,7 @@ where
     WaitingForVote,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ParticipantContext<P, T>
 where
     P: Process,

--- a/libaugrim/src/two_phase_commit/unified_action.rs
+++ b/libaugrim/src/two_phase_commit/unified_action.rs
@@ -34,7 +34,7 @@ where
     Notify(TwoPhaseCommitActionNotification<V>),
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum TwoPhaseCommitActionNotification<V>
 where
     V: Value,

--- a/libaugrim/src/two_phase_commit/unified_context.rs
+++ b/libaugrim/src/two_phase_commit/unified_context.rs
@@ -24,7 +24,7 @@ use super::TwoPhaseCommitState;
 use super::{CoordinatorContext, CoordinatorState, Participant};
 use super::{ParticipantContext, ParticipantState};
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TwoPhaseCommitContext<P, T, R = TwoPhaseCommitRoleContext<P, T>>
 where
     P: Process,

--- a/libaugrim/src/two_phase_commit/unified_message.rs
+++ b/libaugrim/src/two_phase_commit/unified_message.rs
@@ -17,7 +17,7 @@ use crate::message::Message;
 
 use super::Epoch;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum TwoPhaseCommitMessage<V>
 where
     V: Value,

--- a/libaugrim/src/two_phase_commit/unified_state.rs
+++ b/libaugrim/src/two_phase_commit/unified_state.rs
@@ -18,7 +18,7 @@ use crate::time::Time;
 use super::CoordinatorState;
 use super::ParticipantState;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum TwoPhaseCommitState<T> {
     Abort,
     Commit,


### PR DESCRIPTION
This lint appeared in Rust 1.63.
