### PR TITLE
Fix clippy::uninlined-format-args lint

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,8 +38,8 @@ jobs:
     - name: Install Just
       run: cargo install just
     - name: Lint
-      run: just ci-lint
+      run: just lint
     - name: Build
-      run: just ci-build
+      run: just build
     - name: Run tests
-      run: just ci-test
+      run: just test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,3 +1,18 @@
+# Copyright 2021 Cargill Incorporated
+# Copyright 2022-2023 Bitwise IO, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Rust
 
 on:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Print rustc version
       run: rustc --version
     - name: Install Just
-      run: cargo install just
+      run: sudo snap install --edge --classic just
     - name: Lint
       run: just lint
     - name: Build

--- a/justfile
+++ b/justfile
@@ -37,12 +37,6 @@ build:
     done
     echo "\n\033[92mBuild Success\033[0m\n"
 
-ci-build: build
-
-ci-lint: lint
-
-ci-test: test
-
 clean:
     cargo clean
 

--- a/libaugrim/src/error/algorithm.rs
+++ b/libaugrim/src/error/algorithm.rs
@@ -42,8 +42,8 @@ impl Error for AlgorithmError {
 impl Display for AlgorithmError {
     fn fmt(&self, f: &mut Formatter) -> FormatResult {
         match self {
-            AlgorithmError::InvalidState(e) => write!(f, "{}", e),
-            AlgorithmError::Internal(e) => write!(f, "{}", e),
+            AlgorithmError::InvalidState(e) => write!(f, "{e}"),
+            AlgorithmError::Internal(e) => write!(f, "{e}"),
         }
     }
 }

--- a/libaugrim/src/error/internal.rs
+++ b/libaugrim/src/error/internal.rs
@@ -149,10 +149,10 @@ impl error::Error for InternalError {
 impl fmt::Display for InternalError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self.message {
-            Some(m) => write!(f, "{}", m),
+            Some(m) => write!(f, "{m}"),
             None => match &self.source {
                 Some(s) => match &s.prefix {
-                    Some(p) => write!(f, "{}: {}", p, s.source),
+                    Some(p) => write!(f, "{p}: {}", s.source),
                     None => write!(f, "{}", s.source),
                 },
                 None => write!(f, "{}", std::any::type_name::<InternalError>()),

--- a/libaugrim/src/two_phase_commit/coordinator_algorithm.rs
+++ b/libaugrim/src/two_phase_commit/coordinator_algorithm.rs
@@ -526,8 +526,7 @@ where
                 if context_epoch != epoch {
                     return Ok(vec![CoordinatorAction::Notify(
                         CoordinatorActionNotification::MessageDropped(format!(
-                            "epoch {} is not the current epoch {}",
-                            epoch, context_epoch
+                            "epoch {epoch} is not the current epoch {context_epoch}",
                         )),
                     )]);
                 }

--- a/libaugrim/src/two_phase_commit/unified_state.rs
+++ b/libaugrim/src/two_phase_commit/unified_state.rs
@@ -57,8 +57,7 @@ where
             }
             TwoPhaseCommitState::WaitingForVoteRequest | TwoPhaseCommitState::Voted { .. } => {
                 Err(InvalidStateError::with_message(format!(
-                    "invalid state for coordinator: {:?}",
-                    state
+                    "invalid state for coordinator: {state:?}",
                 )))
             }
         }
@@ -89,8 +88,7 @@ where
             TwoPhaseCommitState::WaitingForStart
             | TwoPhaseCommitState::WaitingForDecisionAck { .. }
             | TwoPhaseCommitState::Voting { .. } => Err(InvalidStateError::with_message(format!(
-                "invalid state for participant: {:?}",
-                state
+                "invalid state for participant: {state:?}",
             ))),
         }
     }


### PR DESCRIPTION
This lint requires variables to be inlined in format strings.