### PR TITLE
Fix repo check in the publish github action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
   publish_to_crates:
     needs: build
     if: >-
-      github.repository_owner == 'splintercommunity'
+      github.repository_owner == 'augrim'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Was checking for splintercommunity, should be checking for augrim in this repository.
