### PR TITLE
Remove unused struct

### DIFF
--- a/libaugrim/src/algorithm/mod.rs
+++ b/libaugrim/src/algorithm/mod.rs
@@ -217,8 +217,6 @@ mod tests {
     struct TestEvent(Option<u32>);
     struct TestAction(Option<u32>);
     struct TestContext(u32);
-    #[derive(Debug, Eq, PartialEq, Clone)]
-    struct TestProcess;
 
     struct TestAlgorithm;
 


### PR DESCRIPTION
This struct is not used within the context of tests.  It may be a holdover from an earlier implementation.